### PR TITLE
fix for crashing bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,7 @@ DerivedData
 .idea/
 *.hmap
 
+*.xccheckout
+
 #CocoaPods
 Pods

--- a/Classes/Promise.m
+++ b/Classes/Promise.m
@@ -284,7 +284,7 @@
     // Sets then blocks (wraps the when block in the done block)
     when.when = whenBlock;
     [when then:^(id value) {
-        when.when();
+        if (when.when != nil) when.when();
     } fail:failBlock always:alwaysBlock];
     
     // Sets promises

--- a/Promises/PromisesTests/PromisesTests.m
+++ b/Promises/PromisesTests/PromisesTests.m
@@ -230,4 +230,27 @@
     }];
 }
 
+
+- (void)testWhenNotDefined
+{
+    Deferred *deferred = [Deferred deferred];
+    XCTAssertEqual(deferred.state, PromiseStatePending, @"Deferred state is not equal to PromiseStatePending");
+    
+    NSString *valueToResolveWith = @"Anything";
+    [deferred resolveWith:valueToResolveWith];
+    
+    [deferred then:^(id value) {
+        NSLog(@"Done was called");
+    } fail:^(NSError *error) {
+        NSLog(@"Fail was called");
+    } always:^{
+        NSLog(@"Always was called");
+    }];
+    
+    [When when:@[deferred] then:nil fail:nil always:^{
+        NSLog(@"Always was called with When");
+        XCTAssertTrue(@"Should not crash when the 'then' and 'fail' blocks are not defined");
+    }];
+}
+
 @end


### PR DESCRIPTION
While using When with `then` or `fail` undefined it may call a block variable which will then cause a crash.

@joshdholtz 
