### PR TITLE
Blocks on objects

### DIFF
--- a/Classes/Promise.h
+++ b/Classes/Promise.h
@@ -22,8 +22,14 @@ typedef void (^whenBlock)();
 
 - (PromiseState)state;
 - (Promise*)addDone:(doneBlock)doneBlock;
+- (Promise*)addDoneSelector:(SEL)selector onObject:(id)object;
+
 - (Promise*)addFail:(failBlock)failBlock;
+- (Promise*)addFailSelector:(SEL)selector onObject:(id)object;
+
 - (Promise*)addAlways:(alwaysBlock)alwaysBlock;
+- (Promise*)addAlwaysSelector:(SEL)selector onObject:(id)object;
+
 - (Promise*)then:(doneBlock)doneBlock fail:(failBlock)failBlock always:(alwaysBlock)alwaysBlock;
 
 @end

--- a/Promises.podspec
+++ b/Promises.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Promises"
-  s.version      = "0.1.2"
+  s.version      = "0.2.0"
   s.summary      = "Objective-C implementation of jQuery-ish promises for iOS"
   s.description  = <<-DESC
                     I promise it does something.

--- a/Promises/Promises.xcodeproj/project.pbxproj
+++ b/Promises/Promises.xcodeproj/project.pbxproj
@@ -20,10 +20,12 @@
 		039B70531888EE4300C590F8 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 039B70321888EE4200C590F8 /* Foundation.framework */; };
 		039B70541888EE4300C590F8 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 039B70361888EE4200C590F8 /* UIKit.framework */; };
 		039B705C1888EE4300C590F8 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 039B705A1888EE4300C590F8 /* InfoPlist.strings */; };
-		039B705E1888EE4300C590F8 /* PromisesTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 039B705D1888EE4300C590F8 /* PromisesTests.m */; };
+		039B705E1888EE4300C590F8 /* DeferredTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 039B705D1888EE4300C590F8 /* DeferredTests.m */; };
 		039B706A1888EEA900C590F8 /* Promises.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 039B70681888EEA900C590F8 /* Promises.podspec */; };
 		039B706B1888EEA900C590F8 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 039B70691888EEA900C590F8 /* README.md */; };
 		039B70711888F0D600C590F8 /* Promise.m in Sources */ = {isa = PBXBuildFile; fileRef = 039B70701888F0D600C590F8 /* Promise.m */; };
+		46FDA9B01984CF6C004D469C /* PromiseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46FDA9AF1984CF6C004D469C /* PromiseTests.m */; };
+		46FDA9B21984D15A004D469C /* WhenTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 46FDA9B11984D15A004D469C /* WhenTests.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,11 +57,13 @@
 		039B70511888EE4300C590F8 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		039B70591888EE4300C590F8 /* PromisesTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "PromisesTests-Info.plist"; sourceTree = "<group>"; };
 		039B705B1888EE4300C590F8 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
-		039B705D1888EE4300C590F8 /* PromisesTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = PromisesTests.m; sourceTree = "<group>"; };
+		039B705D1888EE4300C590F8 /* DeferredTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DeferredTests.m; sourceTree = "<group>"; };
 		039B70681888EEA900C590F8 /* Promises.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = Promises.podspec; path = ../Promises.podspec; sourceTree = "<group>"; };
 		039B70691888EEA900C590F8 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		039B706F1888F0D600C590F8 /* Promise.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Promise.h; sourceTree = "<group>"; };
 		039B70701888F0D600C590F8 /* Promise.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Promise.m; sourceTree = "<group>"; };
+		46FDA9AF1984CF6C004D469C /* PromiseTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = PromiseTests.m; sourceTree = "<group>"; };
+		46FDA9B11984D15A004D469C /* WhenTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = WhenTests.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -147,7 +151,9 @@
 		039B70571888EE4300C590F8 /* PromisesTests */ = {
 			isa = PBXGroup;
 			children = (
-				039B705D1888EE4300C590F8 /* PromisesTests.m */,
+				039B705D1888EE4300C590F8 /* DeferredTests.m */,
+				46FDA9AF1984CF6C004D469C /* PromiseTests.m */,
+				46FDA9B11984D15A004D469C /* WhenTests.m */,
 				039B70581888EE4300C590F8 /* Supporting Files */,
 			);
 			path = PromisesTests;
@@ -282,7 +288,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				039B705E1888EE4300C590F8 /* PromisesTests.m in Sources */,
+				039B705E1888EE4300C590F8 /* DeferredTests.m in Sources */,
+				46FDA9B01984CF6C004D469C /* PromiseTests.m in Sources */,
+				46FDA9B21984D15A004D469C /* WhenTests.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -483,6 +491,7 @@
 				039B70631888EE4300C590F8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		039B70641888EE4300C590F8 /* Build configuration list for PBXNativeTarget "PromisesTests" */ = {
 			isa = XCConfigurationList;
@@ -491,6 +500,7 @@
 				039B70661888EE4300C590F8 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/Promises/Promises/AppDelegate.m
+++ b/Promises/Promises/AppDelegate.m
@@ -65,6 +65,7 @@
     [self testWhenResolving];
     [self testWhenNotFinishing];
     [self testWhenSlowAlways];
+    [self testDoneOnAnObject];
     
     return YES;
 }
@@ -145,32 +146,33 @@
     sleep(5);
     [deferred2 resolveWith:@"Yay"];
 }
-							
-- (void)applicationWillResignActive:(UIApplication *)application
-{
-    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
-    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+
+/*
+ * The following method should result in the method below it getting called
+ */
+- (void)testDoneOnAnObject {
+    Deferred *deferred1 = [Deferred deferred];
+    Deferred *deferred2 = [Deferred deferred];
+    
+    [deferred1.promise addDoneSelector:@selector(doneOnAppDelegateWithObject:) onObject:self];
+    [deferred2.promise addFailSelector:@selector(failOnAppDelegateWithError:) onObject:self];
+    [deferred1.promise addAlwaysSelector:@selector(alwaysOnAppDelegate) onObject:self];
+    [deferred2.promise addAlwaysSelector:@selector(alwaysOnAppDelegate) onObject:self];
+    
+    [deferred1 resolveWith:@"Yay"];
+    [deferred2 rejectWith:@"Ruh Roh"];
 }
 
-- (void)applicationDidEnterBackground:(UIApplication *)application
-{
-    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later. 
-    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+- (void)doneOnAppDelegateWithObject:(id)object {
+    NSLog(@"Done called on AppDelegate with object: %@", object);
 }
 
-- (void)applicationWillEnterForeground:(UIApplication *)application
-{
-    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+- (void)failOnAppDelegateWithError:(id)error {
+    NSLog(@"Fail called on AppDelegate with error: %@", error);
 }
 
-- (void)applicationDidBecomeActive:(UIApplication *)application
-{
-    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
-}
-
-- (void)applicationWillTerminate:(UIApplication *)application
-{
-    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+- (void)alwaysOnAppDelegate {
+    NSLog(@"Always called on AppDelegate -- This should happen twice!");
 }
 
 @end

--- a/Promises/PromisesTests/DeferredTests.m
+++ b/Promises/PromisesTests/DeferredTests.m
@@ -10,23 +10,11 @@
 
 #import "Promise.h"
 
-@interface PromisesTests : XCTestCase
+@interface DeferredTests : XCTestCase
 
 @end
 
-@implementation PromisesTests
-
-- (void)setUp
-{
-    [super setUp];
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-}
-
-- (void)tearDown
-{
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-    [super tearDown];
-}
+@implementation DeferredTests
 
 - (void)testDeferredStateResolved
 {
@@ -227,29 +215,6 @@
         NSLog(@"Fail was called");
     } always:^{
         NSLog(@"Always was called");
-    }];
-}
-
-
-- (void)testWhenNotDefined
-{
-    Deferred *deferred = [Deferred deferred];
-    XCTAssertEqual(deferred.state, PromiseStatePending, @"Deferred state is not equal to PromiseStatePending");
-    
-    NSString *valueToResolveWith = @"Anything";
-    [deferred resolveWith:valueToResolveWith];
-    
-    [deferred then:^(id value) {
-        NSLog(@"Done was called");
-    } fail:^(NSError *error) {
-        NSLog(@"Fail was called");
-    } always:^{
-        NSLog(@"Always was called");
-    }];
-    
-    [When when:@[deferred] then:nil fail:nil always:^{
-        NSLog(@"Always was called with When");
-        XCTAssertTrue(@"Should not crash when the 'then' and 'fail' blocks are not defined");
     }];
 }
 

--- a/Promises/PromisesTests/PromiseTests.m
+++ b/Promises/PromisesTests/PromiseTests.m
@@ -1,0 +1,82 @@
+//
+//  PromiseTests.m
+//  Promises
+//
+//  Created by Graham Mueller on 7/27/14.
+//  Copyright (c) 2014 Josh Holtz. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "Promise.h"
+
+@interface StubObject : NSObject
+
+@property (assign, nonatomic) BOOL doneCalled;
+@property (assign, nonatomic) BOOL failCalled;
+@property (assign, nonatomic) BOOL alwaysCalled;
+
+@end
+
+@implementation StubObject
+
+- (void)callAlways {
+    // Since we can't call the setter directly, like we can for done and fail, we have
+    // to add a method that takes no params and manually set alwaysCalled to true.
+    self.alwaysCalled = YES;
+}
+
+@end
+
+@interface PromiseTests : XCTestCase
+
+@end
+
+@implementation PromiseTests
+
+- (void)testAddDoneOnObject {
+    Deferred *deferred = [Deferred deferred];
+    StubObject *stubObject = [[StubObject alloc] init];
+    
+    [deferred addDoneSelector:@selector(setDoneCalled:) onObject:stubObject];
+    
+    [deferred resolveWith:@YES];
+    
+    XCTAssertTrue(stubObject.doneCalled);
+    XCTAssertFalse(stubObject.failCalled);
+    XCTAssertFalse(stubObject.alwaysCalled);
+}
+
+- (void)testAddFailOnObject {
+    Deferred *deferred = [Deferred deferred];
+    StubObject *stubObject = [[StubObject alloc] init];
+    
+    [deferred addFailSelector:@selector(setFailCalled:) onObject:stubObject];
+    
+    [deferred rejectWith:@YES];
+    
+    XCTAssertFalse(stubObject.doneCalled);
+    XCTAssertTrue(stubObject.failCalled);
+    XCTAssertFalse(stubObject.alwaysCalled);
+}
+
+- (void)testAddAlwaysOnObject {
+    Deferred *deferred1 = [Deferred deferred];
+    Deferred *deferred2 = [Deferred deferred];
+    StubObject *stubObject1 = [[StubObject alloc] init];
+    StubObject *stubObject2 = [[StubObject alloc] init];
+    
+    [deferred1 addAlwaysSelector:@selector(callAlways) onObject:stubObject1];
+    [deferred2 addAlwaysSelector:@selector(callAlways) onObject:stubObject2];
+    
+    [deferred1 rejectWith:nil];
+    [deferred2 rejectWith:nil];
+    
+    XCTAssertFalse(stubObject1.doneCalled);
+    XCTAssertFalse(stubObject1.failCalled);
+    XCTAssertTrue(stubObject1.alwaysCalled);
+    XCTAssertFalse(stubObject2.doneCalled);
+    XCTAssertFalse(stubObject2.failCalled);
+    XCTAssertTrue(stubObject2.alwaysCalled);
+}
+
+@end

--- a/Promises/PromisesTests/WhenTests.m
+++ b/Promises/PromisesTests/WhenTests.m
@@ -1,0 +1,40 @@
+//
+//  WhenTests.m
+//  Promises
+//
+//  Created by Graham Mueller on 7/27/14.
+//  Copyright (c) 2014 Josh Holtz. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+#import "Promise.h"
+
+@interface WhenTests : XCTestCase
+
+@end
+
+@implementation WhenTests
+
+- (void)testWhenNotDefined
+{
+    Deferred *deferred = [Deferred deferred];
+    XCTAssertEqual(deferred.state, PromiseStatePending, @"Deferred state is not equal to PromiseStatePending");
+    
+    NSString *valueToResolveWith = @"Anything";
+    [deferred resolveWith:valueToResolveWith];
+    
+    [deferred then:^(id value) {
+        NSLog(@"Done was called");
+    } fail:^(NSError *error) {
+        NSLog(@"Fail was called");
+    } always:^{
+        NSLog(@"Always was called");
+    }];
+    
+    [When when:@[deferred] then:nil fail:nil always:^{
+        NSLog(@"Always was called with When");
+        XCTAssertTrue(@"Should not crash when the 'then' and 'fail' blocks are not defined");
+    }];
+}
+
+@end

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Asynchronous code... blah blah blah... standard interface for... blah blah blah.
 
 Version | Changes
 --- | ---
+**0.2.0** | Added ability to have Promises `then`, `fail`, or `always` via a selector on an object instead of within a block
 **0.1.2** | `then` and `fail` blocks can be undefined now when using `When` (thanks [brennanmke](https://github.com/brennanmke))
 **0.1.1** | Fixed issue with EXC_BAD_ACCESS (thanks [DanielMSchmidt](https://github.com/DanielMSchmidt))
 **0.1.0** | Initial release


### PR DESCRIPTION
I was thinking it might be nice to be able to put your callbacks on actual objects/selectors rather than forcing everything to be in closures. It probably makes it more testable, etc. Basically, the idea is to allow:

```
- (void)doSomethingWithAThen {
    Deferred *deferred = [Deferred deferred];

    [deferred addDoneSelector:@selector(handleDone:) onObject:self];
}

- (void)handleDone:(id)result {
    NSLog(@"OMG, look at this sweet result I got: %@", result);
}
```

It's similar in concept to the JS promises, where you might do:

```
var myClass = {
   doSomethingPromisey: function() {
      var promise = new Promise(); // bluebird
      promise.then(this.handleThen);
   },

   handleThen: function() {
      console.log("OMG, look at all these arguments", arguments);
   }
}
```

Additionally, and not as a part of this, I was wondering if you might consider renaming your API a little bit. The concept of `done` is slightly different than `then`, in that `done`'s are not supposed to be chainable -- they represent the end of a Promise, after which point nothing can attach itself (have a look at [q](https://github.com/kriskowal/q) or [bluebird](https://github.com/petkaantonov/bluebird)). The same would go for the deferred's `resolveWith:` and `rejectWith:` methods; they probably shouldn't return the Promise, as it is 'complete' beyond that point. Just a thought, not sure what your opinion is. Those would both result in breaking API changes, and a potential major version bump.

Another note, which I'm not currently taking the time to handle -- I'm pretty sure that nothing guarantees that adding a `done`, `fail`, or `always` resulting in it actually being called. You check if the state is `pending` or `completed`, but if that state was to change _while_ adding that new handler, it wouldn't be called. I'm not sure if there's an easy fix for that, though. It's not likely a condition you'd run into, but it is possible.
